### PR TITLE
Refactors test utils

### DIFF
--- a/src/test/java/com/codurance/allaboard/acceptance/utils/WebAcceptanceTestTemplate.java
+++ b/src/test/java/com/codurance/allaboard/acceptance/utils/WebAcceptanceTestTemplate.java
@@ -47,20 +47,6 @@ public class WebAcceptanceTestTemplate {
         .body(jsonObject.toString());
   }
 
-  public RequestSpecification httpRequestWithoutAuthorizationHeader() {
-    return httpRequest();
-  }
-
-  public RequestSpecification httpRequestWithEmptyAuthorizationHeader() {
-    return httpRequest()
-        .header(authorization, "");
-  }
-
-  public RequestSpecification httpRequestWithInvalidAuthorizationHeader() {
-    return httpRequest()
-        .header(authorization, "invalid token");
-  }
-
   protected String expectedResponseBody(String jsonFileName) throws IOException {
     StringBuilder sb = new StringBuilder();
     Path filePath = Paths.get("src", "test", "resources", jsonFileName);

--- a/src/test/java/com/codurance/allaboard/acceptance/utils/WebAcceptanceTestTemplate.java
+++ b/src/test/java/com/codurance/allaboard/acceptance/utils/WebAcceptanceTestTemplate.java
@@ -47,9 +47,9 @@ public class WebAcceptanceTestTemplate {
         .body(jsonObject.toString());
   }
 
-  protected String expectedResponseBody(String jsonFileName) throws IOException {
+  protected JSONObject buildJsonObjectFromFile(String filename) throws IOException {
     StringBuilder sb = new StringBuilder();
-    Path filePath = Paths.get("src", "test", "resources", jsonFileName);
+    Path filePath = Paths.get("src", "test", "resources", filename);
 
     try (BufferedReader br = Files.newBufferedReader(
         filePath)) {
@@ -58,6 +58,6 @@ public class WebAcceptanceTestTemplate {
         sb.append(line);
       }
     }
-    return sb.toString();
+    return new JSONObject(sb.toString());
   }
 }

--- a/src/test/java/com/codurance/allaboard/web/acceptance/GetLearningPathByIdFeature.java
+++ b/src/test/java/com/codurance/allaboard/web/acceptance/GetLearningPathByIdFeature.java
@@ -2,6 +2,7 @@ package com.codurance.allaboard.web.acceptance;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.codurance.allaboard.acceptance.utils.WebAcceptanceTestTemplate;
 import io.restassured.RestAssured;
@@ -43,11 +44,12 @@ public class GetLearningPathByIdFeature extends WebAcceptanceTestTemplate {
   @Sql(scripts = "classpath:cleanup.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
   void answers_with_learning_path_if_asked_for_an_existent_one() throws IOException {
     RequestSpecification request = httpRequest();
+    JSONObject expectedResponseBody = buildJsonObjectFromFile("stub-learningpath.json");
 
     Response response = request.get(apiV1Endpoint("/learningpath/1"));
     JSONObject responseBody = buildResponseBody(response);
 
     assertThat(response.statusCode(), is(200));
-    assertThat(responseBody.toString(), is(expectedResponseBody("stub-learningpath.json")));
+    assertTrue(responseBody.similar(expectedResponseBody));
   }
 }

--- a/src/test/java/com/codurance/allaboard/web/acceptance/GetLearningPathByIdFeature.java
+++ b/src/test/java/com/codurance/allaboard/web/acceptance/GetLearningPathByIdFeature.java
@@ -31,6 +31,7 @@ public class GetLearningPathByIdFeature extends WebAcceptanceTestTemplate {
   }
 
   @Test
+  @Sql(scripts = "classpath:cleanup.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
   void answers_not_found_if_asked_for_a_nonexistent_learning_path() {
     RequestSpecification request = httpRequest();
 

--- a/src/test/java/com/codurance/allaboard/web/acceptance/GetLearningPathByIdFeature.java
+++ b/src/test/java/com/codurance/allaboard/web/acceptance/GetLearningPathByIdFeature.java
@@ -17,9 +17,14 @@ import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+import org.springframework.test.context.jdbc.SqlMergeMode;
+import org.springframework.test.context.jdbc.SqlMergeMode.MergeMode;
 
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SqlMergeMode(MergeMode.MERGE)
+@Sql(scripts = "classpath:cleanup.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(scripts = "classpath:cleanup.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
 public class GetLearningPathByIdFeature extends WebAcceptanceTestTemplate {
 
   @LocalServerPort
@@ -31,7 +36,6 @@ public class GetLearningPathByIdFeature extends WebAcceptanceTestTemplate {
   }
 
   @Test
-  @Sql(scripts = "classpath:cleanup.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
   void answers_not_found_if_asked_for_a_nonexistent_learning_path() {
     RequestSpecification request = httpRequest();
 
@@ -42,7 +46,6 @@ public class GetLearningPathByIdFeature extends WebAcceptanceTestTemplate {
 
   @Test
   @Sql(scripts = "classpath:stub-catalogue.sql")
-  @Sql(scripts = "classpath:cleanup.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
   void answers_with_learning_path_if_asked_for_an_existent_one() throws IOException {
     RequestSpecification request = httpRequest();
     JSONObject expectedResponseBody = buildJsonObjectFromFile("stub-learningpath.json");

--- a/src/test/java/com/codurance/allaboard/web/acceptance/GoogleTokenValidationFeature.java
+++ b/src/test/java/com/codurance/allaboard/web/acceptance/GoogleTokenValidationFeature.java
@@ -27,7 +27,7 @@ public class GoogleTokenValidationFeature extends WebAcceptanceTestTemplate {
 
   @Test
   void deny_requests_without_authorization_header() {
-    RequestSpecification request = httpRequestWithoutAuthorizationHeader();
+    RequestSpecification request = httpRequest();
 
     Response response = request.post(apiV1Endpoint("survey"));
 
@@ -36,7 +36,7 @@ public class GoogleTokenValidationFeature extends WebAcceptanceTestTemplate {
 
   @Test
   void deny_requests_with_empty_authorization_header() {
-    RequestSpecification request = httpRequestWithEmptyAuthorizationHeader();
+    RequestSpecification request = httpRequest().header("Authorization", "");
 
     Response response = request.post(apiV1Endpoint("survey"));
 
@@ -45,7 +45,7 @@ public class GoogleTokenValidationFeature extends WebAcceptanceTestTemplate {
 
   @Test
   void deny_requests_with_invalid_authorization_header() {
-    RequestSpecification request = httpRequestWithInvalidAuthorizationHeader();
+    RequestSpecification request = httpRequest();
 
     Response response = request.post(apiV1Endpoint("survey"));
 

--- a/src/test/java/com/codurance/allaboard/web/acceptance/LearningPathsFetchingFeature.java
+++ b/src/test/java/com/codurance/allaboard/web/acceptance/LearningPathsFetchingFeature.java
@@ -18,9 +18,14 @@ import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+import org.springframework.test.context.jdbc.SqlMergeMode;
+import org.springframework.test.context.jdbc.SqlMergeMode.MergeMode;
 
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SqlMergeMode(MergeMode.MERGE)
+@Sql(scripts = "classpath:cleanup.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(scripts = "classpath:cleanup.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
 public class LearningPathsFetchingFeature extends WebAcceptanceTestTemplate {
 
   @LocalServerPort
@@ -33,7 +38,6 @@ public class LearningPathsFetchingFeature extends WebAcceptanceTestTemplate {
 
   @Test
   @Sql(scripts = "classpath:stub-catalogue.sql")
-  @Sql(scripts = "classpath:cleanup.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
   void given_get_fetch_catalogue() throws IOException {
     RequestSpecification httpRequest = httpRequest();
     Response response = httpRequest.get(apiV1Endpoint("learningpath"));

--- a/src/test/java/com/codurance/allaboard/web/acceptance/LearningPathsFetchingFeature.java
+++ b/src/test/java/com/codurance/allaboard/web/acceptance/LearningPathsFetchingFeature.java
@@ -2,6 +2,7 @@ package com.codurance.allaboard.web.acceptance;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.codurance.allaboard.acceptance.utils.WebAcceptanceTestTemplate;
 import io.restassured.RestAssured;
@@ -36,13 +37,14 @@ public class LearningPathsFetchingFeature extends WebAcceptanceTestTemplate {
   void given_get_fetch_catalogue() throws IOException {
     RequestSpecification httpRequest = httpRequest();
     Response response = httpRequest.get(apiV1Endpoint("learningpath"));
+    JSONObject expectedResponseBody = buildJsonObjectFromFile("stub-catalogue.json");
 
     JSONObject responseBody = buildResponseBody(response);
     JSONArray learningPaths = responseBody.getJSONArray("learningPaths");
 
     assertThat(response.statusCode(), is(200));
     assertThat(learningPaths.length(), is(2));
-    assertThat(responseBody.toString(), is(expectedResponseBody("stub-catalogue.json")));
+    assertTrue(responseBody.similar(expectedResponseBody));
   }
 
 }

--- a/src/test/java/com/codurance/allaboard/web/acceptance/LearningPathsFetchingFeature.java
+++ b/src/test/java/com/codurance/allaboard/web/acceptance/LearningPathsFetchingFeature.java
@@ -34,7 +34,7 @@ public class LearningPathsFetchingFeature extends WebAcceptanceTestTemplate {
   @Sql(scripts = "classpath:stub-catalogue.sql")
   @Sql(scripts = "classpath:cleanup.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
   void given_get_fetch_catalogue() throws IOException {
-    RequestSpecification httpRequest = httpRequestWithoutAuthorizationHeader();
+    RequestSpecification httpRequest = httpRequest();
     Response response = httpRequest.get(apiV1Endpoint("learningpath"));
 
     JSONObject responseBody = buildResponseBody(response);

--- a/src/test/java/com/codurance/allaboard/web/acceptance/TopicDetailsFetchingFeature.java
+++ b/src/test/java/com/codurance/allaboard/web/acceptance/TopicDetailsFetchingFeature.java
@@ -17,9 +17,14 @@ import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+import org.springframework.test.context.jdbc.SqlMergeMode;
+import org.springframework.test.context.jdbc.SqlMergeMode.MergeMode;
 
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SqlMergeMode(MergeMode.MERGE)
+@Sql(scripts = "classpath:cleanup.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(scripts = "classpath:cleanup.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
 public class TopicDetailsFetchingFeature extends WebAcceptanceTestTemplate {
 
     @LocalServerPort
@@ -35,7 +40,6 @@ public class TopicDetailsFetchingFeature extends WebAcceptanceTestTemplate {
 
     @Test
     @Sql(scripts = "classpath:stub-topic-subtopics.sql")
-    @Sql(scripts = "classpath:cleanup.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
     void can_access_parse_and_respond_without_resources() throws IOException {
         RequestSpecification httpRequest = httpRequest();
 
@@ -49,7 +53,6 @@ public class TopicDetailsFetchingFeature extends WebAcceptanceTestTemplate {
 
     @Test
     @Sql(scripts = "classpath:stub-topic-subtopics-resources.sql")
-    @Sql(scripts = "classpath:cleanup.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
     void can_access_parse_and_respond_with_resources() throws IOException {
         RequestSpecification httpRequest = httpRequest();
 

--- a/src/test/java/com/codurance/allaboard/web/acceptance/TopicDetailsFetchingFeature.java
+++ b/src/test/java/com/codurance/allaboard/web/acceptance/TopicDetailsFetchingFeature.java
@@ -2,6 +2,7 @@ package com.codurance.allaboard.web.acceptance;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.codurance.allaboard.acceptance.utils.WebAcceptanceTestTemplate;
 import io.restassured.RestAssured;
@@ -40,9 +41,10 @@ public class TopicDetailsFetchingFeature extends WebAcceptanceTestTemplate {
 
         Response response = httpRequest.get(apiV1Endpoint(String.format("topic/%s", ID_OF_TOPIC_WITHOUT_RESOURCES)));
         JSONObject responseBody = buildResponseBody(response);
+        JSONObject expectedResponseBody = buildJsonObjectFromFile("stub-topic-with-subtopics-no-resources.json");
 
         assertThat(response.statusCode(), is(200));
-        assertThat(responseBody.toString(), is(expectedResponseBody("stub-topic-with-subtopics-no-resources.json")));
+        assertTrue(responseBody.similar(expectedResponseBody));
     }
 
     @Test
@@ -53,8 +55,9 @@ public class TopicDetailsFetchingFeature extends WebAcceptanceTestTemplate {
 
         Response response = httpRequest.get(apiV1Endpoint(String.format("topic/%s", ID_OF_TOPIC_WITH_RESOURCES)));
         JSONObject responseBody = buildResponseBody(response);
+        JSONObject expectedResponseBody = buildJsonObjectFromFile("stub-topic-with-subtopics-with-resources.json");
 
         assertThat(response.statusCode(), is(200));
-        assertThat(responseBody.toString(), is(expectedResponseBody("stub-topic-with-subtopics-with-resources.json")));
+        assertTrue(responseBody.similar(expectedResponseBody));
     }
 }

--- a/src/test/resources/cleanup.sql
+++ b/src/test/resources/cleanup.sql
@@ -3,3 +3,4 @@ DELETE FROM subtopics;
 DELETE FROM catalogue_topic;
 DELETE FROM topics;
 DELETE FROM catalogue;
+alter sequence hibernate_sequence restart with 1;

--- a/src/test/resources/stub-catalogue.json
+++ b/src/test/resources/stub-catalogue.json
@@ -1,1 +1,14 @@
-{"learningPaths":[{"name":"first learning path title","description":"first learning path description","id":1},{"name":"second learning path title","description":"second learning path description","id":2}]}
+{
+  "learningPaths": [
+    {
+      "name": "first learning path title",
+      "description": "first learning path description",
+      "id": 1
+    },
+    {
+      "name": "second learning path title",
+      "description": "second learning path description",
+      "id": 2
+    }
+  ]
+}

--- a/src/test/resources/stub-learningpath.json
+++ b/src/test/resources/stub-learningpath.json
@@ -1,1 +1,17 @@
-{"topics":[{"name":"first topic name","description":"first topic description","id":1},{"name":"second topic name","description":"second topic description","id":2}],"name":"first learning path title","description":"first learning path description","id":1}
+{
+  "topics": [
+    {
+      "name": "first topic name",
+      "description": "first topic description",
+      "id": 1
+    },
+    {
+      "name": "second topic name",
+      "description": "second topic description",
+      "id": 2
+    }
+  ],
+  "name": "first learning path title",
+  "description": "first learning path description",
+  "id": 1
+}

--- a/src/test/resources/stub-topic-with-subtopics-no-resources.json
+++ b/src/test/resources/stub-topic-with-subtopics-no-resources.json
@@ -1,1 +1,15 @@
-{"name":"first topic name","subtopics":[{"name":"first subtopic of first topic name","resources":[],"id":1},{"name":"second subtopic of first topic name","resources":[],"id":2}]}
+{
+  "name": "first topic name",
+  "subtopics": [
+    {
+      "name": "first subtopic of first topic name",
+      "resources": [],
+      "id": 1
+    },
+    {
+      "name": "second subtopic of first topic name",
+      "resources": [],
+      "id": 2
+    }
+  ]
+}

--- a/src/test/resources/stub-topic-with-subtopics-with-resources.json
+++ b/src/test/resources/stub-topic-with-subtopics-with-resources.json
@@ -1,1 +1,16 @@
-{"name":"second topic name","subtopics":[{"name":"first subtopic of second topic name","resources":[{"id":1,"label":"first resource of second topic of third subtopic","url":"url 13"}],"id":3}]}
+{
+  "name": "second topic name",
+  "subtopics": [
+    {
+      "name": "first subtopic of second topic name",
+      "resources": [
+        {
+          "id": 1,
+          "label": "first resource of second topic of third subtopic",
+          "url": "url 13"
+        }
+      ],
+      "id": 3
+    }
+  ]
+}


### PR DESCRIPTION
- Removes some template methods that had few usages along project.
- Factory method that returned a `JsonObject` as String from a file name now returns a `JsonObject`. 
- Changes response bodies assertions to use `JsonObject.similar`, which compares fields and values to return true if they're equal.